### PR TITLE
fix: ffmpeg stats every 30 seconds

### DIFF
--- a/src/SuperFlyXXI/VideoConverter/Helpers/FFmpegHelper.php
+++ b/src/SuperFlyXXI/VideoConverter/Helpers/FFmpegHelper.php
@@ -115,7 +115,7 @@ class FFmpegHelper
 
     public static function generate($listRequests, $outputFile)
     {
-        $finalCommand = "ffmpeg ";
+        $finalCommand = "ffmpeg -stats_period 30 ";
         if (EnvHelper::getEnvWithDefault("OVERWRITE_FILE", "true") == "true") {
             $finalCommand .= "-y ";
         }


### PR DESCRIPTION
Save space by being less chatty