### PR TITLE
fix: hardware encoding with software deinterlace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 testResults/
 vendor/
-.phplint-cache
+.phplint.cache/
 **/*.phar
 testdox.txt
 

--- a/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
+++ b/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
@@ -21,8 +21,8 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                 switch ($request->deinterlaceMode) {
                     default:
                     case "00":
-                        $filters .= ",hwdownload,dejudder,fps=" . $stream->frame_rate .
-                            ",fieldmatch,yadif=deint=interlaced,decimate,hwupload";
+                        $filters .= ",hwdownload,format=nv12,dejudder,fps=" . $stream->frame_rate .
+                            ",fieldmatch,yadif=deint=interlaced,decimate,format=nv12,hwupload";
                         // https://ffmpeg.org/ffmpeg-filters.html#fieldmatch
                         break;
                     case "01":
@@ -40,7 +40,7 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                     $request->videoUpscale * $stream->height;
             }
             if (strlen($filters ?? "") > 0) {
-                $args = ' -vf "' . substr($filters, 1) . '"' . $args;
+                $args = '-vf "' . substr($filters, 1) . '"' . $args;
             }
             $args .= " " . $request->videoFormat . " -qp 20 -level:v 4";
         } else {

--- a/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
+++ b/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
@@ -40,7 +40,7 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                     $request->videoUpscale * $stream->height;
             }
             if (strlen($filters ?? "") > 0) {
-                $args = '-vf "' . substr($filters, 1) . '"' . $args;
+                $args = '-init_hw_device vaapi=vaapi:/dev/dri/renderD128 -filter_hw_device vaapi -vf "' . substr($filters, 1) . '"' . $args;
             }
             $args .= " " . $request->videoFormat . " -qp 20 -level:v 4";
         } else {


### PR DESCRIPTION
Since mode `00` is mixing software filters with hardware filters, we need to specify the format and specify the device doing the filtering (in case there are multiple GPUs).

Fixes #397