### PR TITLE
fix(deinterlace): filter order

### DIFF
--- a/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
+++ b/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
@@ -7,6 +7,8 @@ use SuperFlyXXI\VideoConverter\Input\InputFile;
 
 class FFmpegVideoArgGenerator implements FFmpegArgGenerator
 {
+    private const SOFTWARE_DEINTERLACE = ",fieldmatch=order=auto:combmatch=full,yadif=deint=interlaced,decimate";
+
     public function getAdditionalArgs($typeOutTrack, Request $request, $index, $typeInputTrack, Stream $stream)
     {
         $args = " -c:v:" . $typeOutTrack;
@@ -21,7 +23,7 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                 switch ($request->deinterlaceMode) {
                     default:
                     case "00":
-                        $filters .= ",hwdownload,format=nv12,dejudder,fps=" . $stream->frame_rate .
+                        $filters .= ",hwdownload,format=nv12,fps=" . $stream->frame_rate .
                             ",fieldmatch,yadif=deint=interlaced,decimate,format=nv12,hwupload";
                         // https://ffmpeg.org/ffmpeg-filters.html#fieldmatch
                         break;
@@ -49,7 +51,7 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                 switch ($request->deinterlaceMode) {
                     default:
                     case "00":
-                        $filters .= ",dejudder,fps=" . $stream->frame_rate
+                        $filters .= ",fps=" . $stream->frame_rate
                             . ",fieldmatch,yadif=deint=interlaced,decimate";
                         // https://ffmpeg.org/ffmpeg-filters.html#fieldmatch
                         break;

--- a/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
+++ b/src/SuperFlyXXI/VideoConverter/Generators/ffmpeg/FFmpegVideoArgGenerator.php
@@ -24,7 +24,7 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                     default:
                     case "00":
                         $filters .= ",hwdownload,format=nv12,fps=" . $stream->frame_rate .
-                            ",fieldmatch,yadif=deint=interlaced,decimate,format=nv12,hwupload";
+                            self::SOFTWARE_DEINTERLACE . ",format=nv12,hwupload";
                         // https://ffmpeg.org/ffmpeg-filters.html#fieldmatch
                         break;
                     case "01":
@@ -52,7 +52,7 @@ class FFmpegVideoArgGenerator implements FFmpegArgGenerator
                     default:
                     case "00":
                         $filters .= ",fps=" . $stream->frame_rate
-                            . ",fieldmatch,yadif=deint=interlaced,decimate";
+                            . self::SOFTWARE_DEINTERLACE;
                         // https://ffmpeg.org/ffmpeg-filters.html#fieldmatch
                         break;
                     case "01":

--- a/tests/DeinterlaceModeTest.php
+++ b/tests/DeinterlaceModeTest.php
@@ -14,17 +14,12 @@ final class DeinterlaceModeTest extends TestSetup
             "sameFramerate" => [
                 "02",
                 "30000/1001"
+            ],
+            "fieldmatch" => [
+                "00",
+                "24000/1001"
             ]
         ];
-    }
-
-    /**
-     *
-     * @test
-     */
-    public function testDeinterlaceMode00()
-    {
-        $this->assertTrue(true, "Already covered by auto-detection tests");
     }
 
     #[DataProvider('dataProvider')]


### PR DESCRIPTION
Fixes fieldmatch to use full combmatch settings to better detect interlaced frames. Allows yadif to deinterlace those frames correctly.